### PR TITLE
fix: dbus bus name

### DIFF
--- a/lib/audio_service_mpris.dart
+++ b/lib/audio_service_mpris.dart
@@ -84,7 +84,7 @@ class AudioServiceMpris extends AudioServicePlatform {
 
     await _dBusClient.registerObject(_mpris);
     await _dBusClient.requestName(
-        'org.mpris.MediaPlayer2.${request.config.androidNotificationChannelId}.instance$pid',
+        'org.mpris.MediaPlayer2.${request.config.androidNotificationChannelName}',
         flags: {DBusRequestNameFlag.doNotQueue});
   }
 

--- a/lib/audio_service_mpris.dart
+++ b/lib/audio_service_mpris.dart
@@ -31,7 +31,9 @@ class AudioServiceMpris extends AudioServicePlatform {
 
   void _listenToControlStream() {
     _mpris.controlStream.listen((event) {
-      debugPrint('Requested from DBus: $event');
+      if (kDebugMode) {
+        debugPrint('Requested from DBus: $event');
+      }
       if (_handlerCallbacks == null) return;
 
       switch (event) {
@@ -66,7 +68,9 @@ class AudioServiceMpris extends AudioServicePlatform {
 
   @override
   Future<void> configure(ConfigureRequest request) async {
-    debugPrint('Configure AudioServiceLinux.');
+    if (kDebugMode) {
+      debugPrint('Configure AudioServiceLinux.');
+    }
 
     _dBusClient = DBusClient.session();
     _mpris = OrgMprisMediaPlayer2(
@@ -93,7 +97,9 @@ class AudioServiceMpris extends AudioServicePlatform {
 
   @override
   Future<void> setQueue(SetQueueRequest request) async {
-    debugPrint('setQueue() has not been implemented.');
+    if (kDebugMode) {
+      debugPrint('setQueue() has not been implemented.');
+    }
   }
 
   @override

--- a/lib/mpris.dart
+++ b/lib/mpris.dart
@@ -115,7 +115,10 @@ class OrgMprisMediaPlayer2 extends DBusObject {
 
   /// Sets property org.mpris.MediaPlayer2.Player.LoopStatus
   Future<DBusMethodResponse> setLoopStatus(String value) async {
-    debugPrint('Set org.mpris.MediaPlayer2.Player.LoopStatus not implemented');
+    if (kDebugMode) {
+      debugPrint(
+          'Set org.mpris.MediaPlayer2.Player.LoopStatus not implemented');
+    }
     return DBusMethodSuccessResponse([]);
   }
 
@@ -126,7 +129,9 @@ class OrgMprisMediaPlayer2 extends DBusObject {
 
   /// Sets property org.mpris.MediaPlayer2.Player.Rate
   Future<DBusMethodResponse> setRate(double value) async {
-    debugPrint('Set org.mpris.MediaPlayer2.Player.Rate not implemented');
+    if (kDebugMode) {
+      debugPrint('Set org.mpris.MediaPlayer2.Player.Rate not implemented');
+    }
     return DBusMethodSuccessResponse([]);
   }
 
@@ -151,7 +156,9 @@ class OrgMprisMediaPlayer2 extends DBusObject {
 
   /// Gets value of property org.mpris.MediaPlayer2.Player.Volume
   Future<DBusMethodResponse> getVolume() async {
-    debugPrint('Get org.mpris.MediaPlayer2.Player.Volume not implemented');
+    if (kDebugMode) {
+      debugPrint('Get org.mpris.MediaPlayer2.Player.Volume not implemented');
+    }
     return DBusMethodSuccessResponse([const DBusDouble(1.0)]);
   }
 
@@ -163,7 +170,9 @@ class OrgMprisMediaPlayer2 extends DBusObject {
 
   /// Gets value of property org.mpris.MediaPlayer2.Player.Position
   Future<DBusMethodResponse> getPosition() async {
-    debugPrint('GetPosition(): $position');
+    if (kDebugMode) {
+      debugPrint('GetPosition(): $position');
+    }
     return DBusMethodSuccessResponse(
         [DBusVariant(DBusInt64(position.inMicroseconds))]);
   }
@@ -246,7 +255,9 @@ class OrgMprisMediaPlayer2 extends DBusObject {
 
   /// Implementation of org.mpris.MediaPlayer2.Player.Seek()
   Future<DBusMethodResponse> doSeek(int offset) async {
-    debugPrint('org.mpris.MediaPlayer2.Player.Seek() not implemented');
+    if (kDebugMode) {
+      debugPrint('org.mpris.MediaPlayer2.Player.Seek() not implemented');
+    }
     return DBusMethodSuccessResponse([]);
   }
 
@@ -426,7 +437,9 @@ class OrgMprisMediaPlayer2 extends DBusObject {
 
   @override
   Future<DBusMethodResponse> getProperty(String interface, String name) async {
-    debugPrint('Requested property $name from $interface');
+    if (kDebugMode) {
+      debugPrint('Requested property $name from $interface');
+    }
 
     if (interface == 'org.mpris.MediaPlayer2') {
       if (name == 'CanQuit') {


### PR DESCRIPTION
The bus name does not need a PID and should be the same everywhere, otherwise applications inside a snap will fail.
with 
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: org.freedesktop.DBus.Error.AccessDenied: Connection ":1.1306" is not allowed to own the service "org.mpris.MediaPlayer2.XXX.instance66710" due to AppArmor policy
