### PR TITLE
feat: Disallow null androidNotificationChannelId/DBus ID

### DIFF
--- a/lib/audio_service_mpris.dart
+++ b/lib/audio_service_mpris.dart
@@ -67,7 +67,8 @@ class AudioServiceMpris extends AudioServicePlatform {
   @override
   Future<void> configure(ConfigureRequest request) async {
     log('Configure AudioServiceLinux.', name: 'audio_service_mpris');
-    assert(request.config.androidNotificationChannelId != null);
+    assert(request.config.androidNotificationChannelId != null,
+          "androidNotificationChannelId is required for registering DBus object. e.g com.ryanheise.myapp.channel.audio");
 
     _dBusClient = DBusClient.session();
     _mpris = OrgMprisMediaPlayer2(

--- a/lib/audio_service_mpris.dart
+++ b/lib/audio_service_mpris.dart
@@ -67,6 +67,7 @@ class AudioServiceMpris extends AudioServicePlatform {
   @override
   Future<void> configure(ConfigureRequest request) async {
     log('Configure AudioServiceLinux.', name: 'audio_service_mpris');
+    assert(request.config.androidNotificationChannelId != null);
 
     _dBusClient = DBusClient.session();
     _mpris = OrgMprisMediaPlayer2(


### PR DESCRIPTION
Avoids user from dumb things like
``
Filtering message due to arg0 org.mpris.MediaPlayer2.null.instance2, policy: 0 (required 3)
*HIDDEN* (ping)
``