### PR TITLE
fix: restore MPRIS controller lifecycle for player exit/re-entry

### DIFF
--- a/lib/audio_service_mpris.dart
+++ b/lib/audio_service_mpris.dart
@@ -17,6 +17,8 @@ class AudioServiceMpris extends AudioServicePlatform {
   late final _MprisMediaPlayer _mpris;
   AudioHandlerCallbacks? _handlerCallbacks;
   bool _isPlaying = false;
+  bool _isRegistered = false;
+  String? _serviceName;
 
   static void registerWith() {
     AudioServicePlatform.instance = AudioServiceMpris();
@@ -189,15 +191,14 @@ class AudioServiceMpris extends AudioServicePlatform {
     _listenToMethodEvents();
 
     await _dBusClient.registerObject(_mpris);
-    await _dBusClient.requestName(
-      'org.mpris.MediaPlayer2.${_defaults.dBusName}.instance$pid',
-      flags: {DBusRequestNameFlag.doNotQueue},
-    );
+    _serviceName = 'org.mpris.MediaPlayer2.${_defaults.dBusName}.instance$pid';
+    await _registerIfNeeded();
     _mpris.identity = _defaults.identity;
   }
 
   @override
   Future<void> setState(SetStateRequest request) async {
+    await _registerIfNeeded();
     _mpris.position = request.state.updatePosition;
     _isPlaying = request.state.playing;
     _mpris.playbackState = _isPlaying ? 'Playing' : 'Paused';
@@ -211,6 +212,7 @@ class AudioServiceMpris extends AudioServicePlatform {
 
   @override
   Future<void> setMediaItem(SetMediaItemRequest request) async {
+    await _registerIfNeeded();
     List<String>? artist;
     if (request.mediaItem.artist != null) artist = [request.mediaItem.artist!];
 
@@ -229,6 +231,26 @@ class AudioServiceMpris extends AudioServicePlatform {
   @override
   Future<void> stopService(StopServiceRequest request) async {
     _mpris.playbackState = 'Stopped';
+    await _unregisterIfNeeded();
+  }
+
+  Future<void> _registerIfNeeded() async {
+    if (_isRegistered) return;
+    if (_serviceName != null) {
+      await _dBusClient.requestName(
+        _serviceName!,
+        flags: {DBusRequestNameFlag.doNotQueue},
+      );
+    }
+    _isRegistered = true;
+  }
+
+  Future<void> _unregisterIfNeeded() async {
+    if (!_isRegistered) return;
+    if (_serviceName != null) {
+      await _dBusClient.releaseName(_serviceName!);
+    }
+    _isRegistered = false;
   }
 
   @override


### PR DESCRIPTION
# Summary
This PR fixes Linux MPRIS media controller lifecycle issues in `audio_service_mpris`.
After this change:
- Media controls disappear when exiting the video player (without closing the app).
- Media controls are restored when playback starts again.
- The fix is scoped to MPRIS lifecycle handling with minimal code changes.
# Root Cause
The MPRIS object registration and service name lifecycle were not aligned:
- Releasing the service during stop removed visibility.
- Unregistering the DBus object on stop prevented clean reappearance on next playback.
# What Changed
- Register the MPRIS DBus object once during `configure()`.
- Keep object registration persistent across stop/start cycles.
- On stop, release only the DBus service name (do not unregister the object).
- On resume, request the service name again via existing register-if-needed flow.
# Result
Linux media controls now:
- disappear reliably after leaving the player,
- reappear reliably when going back to the player.